### PR TITLE
♿🎆 Remove aria-label

### DIFF
--- a/packages/ds/src/components/button/button.stories.mdx
+++ b/packages/ds/src/components/button/button.stories.mdx
@@ -151,6 +151,39 @@ Primitive button component with primary, secondary & transparent variants
   </Story>
 </Preview>
 
+### Accessibility
+
+You may provide labelling alternatives for use with assistive-technologies (AT) using wai-aria attributes.
+Below is a table of commonly used `aria-attributes` for labelling elements.
+
+Click the attribute in the table below for more information.
+
+<Box mb={4}>
+  <Flex flexDirection="column">
+
+Attribute | Description
+--- | ---
+<nobr>[**`aria-label`**](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-label)</nobr> | Provide an accessible name for situations when there is no visible label due to a chosen design approach or layout but the context and visual appearance of the control make its purpose clear.
+<nobr>[**`aria-labelledby`**](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-labelledby)</nobr> | Associate an element with text that is visible elsewhere on the page by using an ID reference value that matches the ID attribute of the labeling element.
+<nobr>[**`aria-describedby`**](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-describedby)</nobr> | Provide programmatically determined, descriptive information about a user interface element.
+
+#### Code Examples 
+
+```jsx
+<Button aria-label="Open the Modal">Open</Button>
+
+<span id='close-label'>Close the Modal</span>
+<Button aria-labelledby="close-label"><img src="./x-btn.png" /></Button>
+
+<Button aria-describedby="desc-label-1, desc-label-2">OK</Button>
+<span id='desc-label-1'>You acknowledge this notice.</span>
+<span id='desc-label-2'>Close the Modal</span>
+```
+
+
+  </Flex>
+</Box>
+
 ## Component Props
 
 <Props of={Button} />

--- a/packages/ds/src/components/button/button.tsx
+++ b/packages/ds/src/components/button/button.tsx
@@ -169,7 +169,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       mt={mt}
       ml={ml}
       mr={mr}
-      {...(isLoading ? { 'aria-label': 'loading' } : {})}
     >
       {isLoading && (
         <Spinner


### PR DESCRIPTION
See Github Issue: #73 for more details regarding this PR.

> ... add a section on how you can provide that accessibility label on the docs page

How should this be constructed in Storybook?  Is there some sort of template or schema to follow for implementing this section in the docs?   _This might need to move to another issue for adding a section in the docs specifically for Accessibility._


