### PR TITLE
🐛 Fix icon-template for aria-labelledby issue

### DIFF
--- a/packages/ds/icon-template.js
+++ b/packages/ds/icon-template.js
@@ -27,7 +27,7 @@ function template(
       SVGSVGElement,
       React.SVGProps<SVGSVGElement> & { title?: any; }
     >(({ title, ...props }, svgRef) => {
-        const [titleId] = useState(() => uuid());
+        const [titleId] = useState(() => (title? uuid(): undefined));
 
         return (
           ${jsx}


### PR DESCRIPTION
See Github Issue #76 for more details regarding this bug.

Solution was to determine if title is being passed through to create the uuid.  If not, titleId represents undefined, which will remove the attribute from the svg node.
