### PR TITLE
refactor:storybook => basic-css /114

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,8 +21,9 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
     "@storybook/addon-storysource",
+    "@storybook/addon-designs",
     "storybook-design-token",
-    "@geometricpanda/storybook-addon-badges"
+    "@geometricpanda/storybook-addon-badges",
   ],
   typescript: {
     check: true,

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,28 +4,28 @@ module.exports = {
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.
 
-    config.resolve.alias['crypto'] = "crypto-browserify";
-    config.resolve.alias['stream'] = "stream-browserify";
+    config.resolve.alias['crypto'] = 'crypto-browserify';
+    config.resolve.alias['stream'] = 'stream-browserify';
 
     // Return the altered config
     return config;
   },
   core: {
-    builder: "webpack5",
+    builder: 'webpack5',
   },
   staticDirs: ['../src/imgs'],
   stories: ['../src/**/*.stories.@(js|tsx|mdx)'],
   addons: [
-    "@storybook/preset-scss",
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-a11y",
-    "@storybook/addon-storysource",
-    "@storybook/addon-designs",
-    "storybook-design-token",
-    "@geometricpanda/storybook-addon-badges",
+    '@storybook/preset-scss',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
+    '@storybook/addon-storysource',
+    'storybook-addon-designs',
+    'storybook-design-token',
+    '@geometricpanda/storybook-addon-badges',
   ],
   typescript: {
     check: true,
-  }
+  },
 };

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -10,4 +10,8 @@ addons.setConfig({
   panelPosition: 'bottom',
   sidebarAnimations: true,
   isToolshown: true,
-})
+});
+
+addons.setConfig({
+  showRoots: false,
+});

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,6 @@
 import { addParameters } from '@storybook/react';
+import { withDesign } from 'storybook-addon-designs';
+
 import '../src/styles/index.scss';
 
 const tokenContext = require.context(
@@ -25,6 +27,7 @@ export const parameters = {
     files: tokenFiles,
   },
 };
+export const globalDecorators = [withDesign];
 
 addParameters({
   viewport: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -13,7 +13,7 @@ const tokenFiles = tokenContext.keys().map(function (filename) {
 
 export const parameters = {
   viewMode: 'docs',
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
@@ -22,16 +22,9 @@ export const parameters = {
   },
   docs: { inlineStories: true },
   designToken: {
-    files: tokenFiles
-  }
-}
-
-addParameters({
-  options: {
-    showRoots: true,
+    files: tokenFiles,
   },
-});
-
+};
 
 addParameters({
   viewport: {
@@ -65,6 +58,5 @@ addParameters({
         },
       },
     },
-    defaultViewport: 'Small Mobile',
   },
 });

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -27,7 +27,7 @@ export const parameters = {
     files: tokenFiles,
   },
 };
-export const globalDecorators = [withDesign];
+export const decorators = [withDesign];
 
 addParameters({
   viewport: {

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -31,6 +31,7 @@ export default create({
   // inputTextColor: 'black',
   // inputBorderRadius: 4,
 
+  // TODO: Inject company name and brand image
   brandTitle: 'Radius',
   brandUrl: 'https://rangle.io/radius',
   brandImage: 'radius_logo_inverted.png',

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
   },
   "typesVersions": {
     "*": {
-      "button": ["dist/button.d.ts"],
-      "tag": ["dist/tag.d.ts"]
+      "button": [
+        "dist/button.d.ts"
+      ],
+      "tag": [
+        "dist/tag.d.ts"
+      ]
     }
   },
   "engines": {
@@ -57,7 +61,8 @@
   "name": "radius-limeade",
   "author": "Sumit Arora",
   "module": "dist/radius.esm.js",
-  "size-limit": [{
+  "size-limit": [
+    {
       "path": "dist/radius.cjs.production.min.js",
       "limit": "10 KB"
     },
@@ -110,6 +115,7 @@
     "sass": "1.49.7",
     "sass-loader": "12.4.0",
     "size-limit": "^5.0.1",
+    "storybook-addon-designs": "^6.2.1",
     "storybook-design-token": "^1.4.0",
     "style-loader": "3.3.1",
     "styled-components": "^5.3.0",

--- a/src/components/box/box.stories.tsx
+++ b/src/components/box/box.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Description, Props, Title } from '@storybook/addon-docs';
+import { ArgsTable, Description, Title } from '@storybook/addon-docs';
 
 import { DsBox } from './box';
 
@@ -15,7 +15,7 @@ export default {
           <Description>
             Building block of layouts. Creates a box-model context
           </Description>
-          <Props of={DsBox} />
+          <ArgsTable of={DsBox} />
         </>
       ),
     },

--- a/src/components/box/box.stories.tsx
+++ b/src/components/box/box.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Description, Props, Title } from '@storybook/addon-docs/blocks';
+import { Description, Props, Title } from '@storybook/addon-docs';
 
-import DsBox from './box';
+import { DsBox } from './box';
 
 export default {
   title: 'Components/Box',
@@ -12,7 +12,9 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description>Building block of layouts. Creates a box-model context</Description>
+          <Description>
+            Building block of layouts. Creates a box-model context
+          </Description>
           <Props of={DsBox} />
         </>
       ),
@@ -24,8 +26,6 @@ export const Basic = (args: any) => <DsBox {...args} />;
 
 export const Primary = () => (
   <DsBox>
-    <h1>
-      This is a box
-    </h1>
+    <h1>This is a box</h1>
   </DsBox>
-)
+);

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,33 +1,42 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
-import DsButton, { DsButtonProps } from './button';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { DsButton, DsButtonProps } from './button';
 
 export default {
   component: DsButton,
   title: 'Components/Button',
-} as Meta;
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/RqENxZWAzGiEWM7COch1Sc/Radius-Design-Kit?node-id=1%3A6',
+    },
+  },
+} as ComponentMeta<typeof DsButton>;
 
-const Template: Story<DsButtonProps> = (args) => <DsButton {...args}>Hello Button</DsButton>;
+const Template: ComponentStory<typeof DsButton> = (args: DsButtonProps) => (
+  <DsButton {...args}>Hello Button</DsButton>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
   variant: 'primary',
   size: 'medium',
-  label: 'Primary Button'
+  label: 'Primary Button',
+  disabled: false,
 };
-
 
 export const Secondary = Template.bind({});
 Secondary.args = {
   variant: 'secondary',
+  disabled: false,
   size: 'medium',
-  label: 'Secondary Button'
+  label: 'Secondary Button',
 };
 
-export const Disabled: Story<DsButtonProps> = (args) => <DsButton {...args}>Hello Button</DsButton>;
+export const Disabled = Template.bind({});
 Disabled.args = {
   variant: 'primary',
   disabled: true,
   size: 'medium',
-  label: 'Primary Disabled Button'
+  label: 'Primary Disabled Button',
 };

--- a/src/components/tag/tag.stories.tsx
+++ b/src/components/tag/tag.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import DsTag, { DsTagProps } from './tag';
+import { DsTag, DsTagProps } from './tag';
 
 export default {
   component: DsTag,
@@ -11,65 +11,63 @@ const Template: Story<DsTagProps> = (args) => <DsTag {...args}>Tag</DsTag>;
 
 export const PrimarySolid = Template.bind({});
 PrimarySolid.args = {
-  label: 'Primary Solid'
+  label: 'Primary Solid',
 };
 
 export const SecondarySolid = Template.bind({});
 SecondarySolid.args = {
   type: 'secondary',
-  label: 'Secondary Solid'
+  label: 'Secondary Solid',
 };
 
 export const ErrorSolid = Template.bind({});
 ErrorSolid.args = {
   type: 'error',
-  label: 'Error Solid'
+  label: 'Error Solid',
 };
 
 export const SuccessSolid = Template.bind({});
 SuccessSolid.args = {
   type: 'success',
-  label: 'Success Solid'
+  label: 'Success Solid',
 };
 
 export const AlertSolid = Template.bind({});
 AlertSolid.args = {
   type: 'alert',
-  label: 'Alert Solid'
+  label: 'Alert Solid',
 };
-
 
 export const PrimaryOutline = Template.bind({});
 PrimaryOutline.args = {
   variant: 'outline',
-  label: 'Primary Outline'
+  label: 'Primary Outline',
 };
-
 
 export const SecondaryOutline = Template.bind({});
 SecondaryOutline.args = {
   type: 'secondary',
   variant: 'outline',
-  label: 'Secondary Outline'
+  label: 'Secondary Outline',
 };
 
 export const ErrorOutline = Template.bind({});
 ErrorOutline.args = {
   type: 'error',
   variant: 'outline',
-  label: 'Error Outline'
+  label: 'Error Outline',
 };
 
 export const SuccessOutline = Template.bind({});
 SuccessOutline.args = {
   type: 'success',
   variant: 'outline',
-  label: 'Success Outline'
+  label: 'Success Outline',
 };
 
 export const AlertOutline = Template.bind({});
 AlertOutline.args = {
   type: 'alert',
   variant: 'outline',
-  label: 'Alert Outline'
+  label: 'Alert Outline',
 };


### PR DESCRIPTION

## Purpose
- Eliminate console noise with deprecated addons and param configs in Storybook 
- Refactor and provide an example of CSF 4
- Tool Storybook with a figma preview addon panel in `button.stories.tsx`

"Console Noise" such as:
![cannot-find-default-viewport](https://user-images.githubusercontent.com/6406037/165739217-de4188e6-25b7-4928-9762-7f78da8005f3.jpg)
![addon_docs_deprecation](https://user-images.githubusercontent.com/6406037/165739235-732e4378-6b6c-45fe-8633-730e00b90b6b.jpg)

## Changes
  - replace deprecated `Props => ArgsTable` import from `@storybook/addon-docs`
  - add withDesign decorator to make available to all stories
  - Adds `storybook-addon-designs` addon in .storybook/main.ts
  - turn .storybook/ config files from `.js` to `.ts`
  - provide an example of story written in CSF 4 in `button.stories.tsx`
  - provide example of how to use design/figma params in `button.stories.tsx`
  
![image](https://user-images.githubusercontent.com/6406037/165740189-697fe772-cb51-406f-ae90-3578c1c92152.png)


Closes #114 
